### PR TITLE
add gif/webp/openjp207 deps to leptonica

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN apt-get update && apt-get install -y \
 	libicu-dev \
 	libjpeg-dev \
 	libpango1.0-dev \
-	libpango1.0-dev \
+	libgif-dev \
+	libwebp-dev \
+	libopenjp2-7-dev \
 	libpng-dev \
 	libtiff-dev \
 	libtool \


### PR DESCRIPTION
leptonica can use all these dependencies:

https://github.com/DanBloomberg/leptonica/blob/master/CMakeLists.txt#L74

libpango1.0-dev was duplicated so removed.